### PR TITLE
Improvements to `to_base` function

### DIFF
--- a/src/lib/fmt.mbt
+++ b/src/lib/fmt.mbt
@@ -80,14 +80,15 @@ fn format_general(num: Double, precision: Int, uppercase: Bool) -> String {
 pub fn to_base(val : Int, base : Int, uppercase : Bool) -> String {
   let digits = match base {
     8 => "01234567"
+    10 => "0123456789"
     16 => if uppercase { "0123456789ABCDEF" } else { "0123456789abcdef" }
     _ => return "Unsupported base"
   }
   if val == 0 {
     return "0"
   }
-
-  let is_negative = (base == 10) && (val < 0)    // 只在十进制时处理负号
+  
+  let is_negative = (base == 10) && (val < 0)
   let mut num = val.abs()
   let mut result = ""
   while num > 0 {

--- a/src/lib/fmt.mbt
+++ b/src/lib/fmt.mbt
@@ -87,7 +87,7 @@ pub fn to_base(val : Int, base : Int, uppercase : Bool) -> String {
     return "0"
   }
 
-  let is_negative = val < 0
+  let is_negative = (base == 10) && (val < 0)    // 只在十进制时处理负号
   let mut num = val.abs()
   let mut result = ""
   while num > 0 {

--- a/src/lib/fmt.mbt
+++ b/src/lib/fmt.mbt
@@ -86,12 +86,17 @@ pub fn to_base(val : Int, base : Int, uppercase : Bool) -> String {
   if val == 0 {
     return "0"
   }
+
+  let is_negative = val < 0
+  let mut num = val.abs()
   let mut result = ""
-  let mut num = val
   while num > 0 {
     let remainder = num % base
     result = result + digits[remainder].to_string()
     num /= base
+  }
+  if is_negative {
+    result = result + "-"
   }
   result.rev()
 }


### PR DESCRIPTION
This pull request includes a significant update to the `to_base` function to handle negative numbers correctly when converting to base 10. The most important changes include adding support for base 10 digits, handling negative values for base 10, and ensuring the negative sign is appended correctly.

Improvements to `to_base` function:

* Added support for base 10 digits in the `digits` match statement.
* Introduced `is_negative` variable to check if the value is negative and the base is 10.
* Updated the logic to work with the absolute value of the number and append a negative sign if necessary.