### PR TITLE
Improvements to `format_decimal` function

### DIFF
--- a/src/lib/fmt.mbt
+++ b/src/lib/fmt.mbt
@@ -126,14 +126,20 @@ fn format_scientific(num : Double, precision : Int, uppercase : Bool) -> String 
 // 浮点数格式化函数
 ///|
 pub fn format_decimal(num : Double, precision : Int, mode : Bool) -> String {
+  // 负零检测
+  let mut number = num
+  if number == 0.0 {
+    number = 0.0
+  }
+  
   let mut scale = 1
   for i = 0; i < precision; i = i + 1 {
     scale *= 10
   }
   let rounded = if mode {
-    (num * scale.to_double() + 0.5).to_int() // 四舍五入
+    (number * scale.to_double() + 0.5).to_int()
   } else {
-    (num * scale.to_double()).to_int() // 直接截断
+    (number * scale.to_double()).to_int()
   }
   let integer_part = (rounded / scale).to_string()
   let decimal_part = (rounded % scale).to_string()

--- a/src/lib/fmt.mbt
+++ b/src/lib/fmt.mbt
@@ -140,8 +140,15 @@ pub fn format_decimal(num : Double, precision : Int, mode : Bool) -> String {
   let mut result = integer_part
   if precision >= 1 {
     result = result + "." + decimal_part
+    // 去除多余零
+    while result.ends_with("0") {
+      result = result.substring(start = 0, end = result.length() - 1)
+    }
+    if result.ends_with(".") {
+      result = result.substring(start = 0, end = result.length() - 1)
+    }
   }
-  return result
+  result
 }
 
 ///|


### PR DESCRIPTION
This pull request includes changes to the `format_decimal` function in the `src/lib/fmt.mbt` file to improve the handling of zero values and trailing zeros. The most important changes include adding a check for negative zero and removing unnecessary trailing zeros from the formatted result.

Improvements to `format_decimal` function:

* Added a check to handle negative zero by setting it to positive zero.
* Modified the rounding logic to use the updated `number` variable instead of `num`.
* Added logic to remove unnecessary trailing zeros from the decimal part of the formatted result.
* Ensured that the result does not end with a decimal point if there are no decimal digits.